### PR TITLE
Remove newline after docblock

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ module.exports = function(file) {
 
     if (isJSXExtension || isJSXPragma && isJSExtensionRe.exec(file)) {
       if (isJSXExtension && !isJSXPragma) {
-        data = '/** @jsx React.DOM */\n' + data;
+        data = '/** @jsx React.DOM */' + data;
       }
       try {
         transformed = react.transform(data);

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -22,7 +22,7 @@ module.exports = (file) ->
   compile = ->
     if isJSXExtension or isJSXPragma and isJSExtensionRe.exec file
       if isJSXExtension and not isJSXPragma
-        data = '/** @jsx React.DOM */\n' + data
+        data = '/** @jsx React.DOM */' + data
       try
         transformed = react.transform(data)
       catch e


### PR DESCRIPTION
This removes the newline after the jsx docblock. It's not needed, and it should keep line counts consistent for tracebacks.
