### PR TITLE
add package.json instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ short notation and classes. You can activate this via `--es6` or `--harmony`
 boolean option:
 
     % browserify -t [ reactify --es6 ] main.js
+    
+You can also configure it in package.json
+
+```json
+{
+    "name": "my-package",
+    "browserify": {
+        "transform": [ 
+            ["reactify", {"es6": true}] 
+        ]
+    }
+}
+```
 
 ## Using 3rd-party jstransform visitors
 


### PR DESCRIPTION
This is documented in [module-deps](https://github.com/substack/module-deps#packagejson-transformkey), which is used by browserify.  You can then simply do `browserify a.jsx -o b.js` and get all the es6 goodness :-)
