### PR TITLE
Decorate existing Error object from react-tools transform

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ function process(file, isJSXFile, transformer) {
         this.queue(transformed);
       } catch (error) {
         error.name = 'ReactifyError';
+        error.message = file + ': ' + error.message;
         error.fileName = file;
 
         this.emit('error', error);


### PR DESCRIPTION
This patch preserves errors thrown from transformation and decorates them
instead of turning them into a simple string.
