### PR TITLE
fix react-tools version to 0.11.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "jstransform": "^6.0.1",
     "through": "~2.3.4",
-    "react-tools": ">= 0.11.0"
+    "react-tools": "0.11.x"
   },
   "devDependencies": {
     "browserify": "4.x.x",


### PR DESCRIPTION
A PR candidate for a 0.14.1 version which use react-tools version 0.11.x, in order to supports react 0.11.x

React 0.12.x as some breaking changes and it's currently impossible to use reactify for a 0.11.x react project.
