### PR TITLE
`--target es5` enables es6 class getters and setters

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ boolean option:
 
     % browserify -t [ reactify --es6 ] main.js
 
+es6 class getter and setter methods can be activated via `--target es5` option:
+
+    % browserify -t [ reactify --es6 --target es5 ] main.js
+
 You can also configure it in package.json
 
 ```json

--- a/index.js
+++ b/index.js
@@ -71,8 +71,12 @@ module.exports = function(file, options) {
     });
   }
 
+  var transformOptions = {
+    es5: options.target === 'es5'
+  };
+
   function transformer(source) {
-    return transform(transformVisitors, source).code;
+    return transform(transformVisitors, source, transformOptions).code;
   }
 
   return process(file, isJSXFile, transformer);

--- a/test/fixtures/main.es6-target-es5.jsx
+++ b/test/fixtures/main.es6-target-es5.jsx
@@ -1,0 +1,3 @@
+class Foo {
+  get bar() {}
+}

--- a/test/reactify.js
+++ b/test/reactify.js
@@ -52,7 +52,7 @@ describe('reactify', function() {
     });
   });
 
-  describe('transforming files with extensions others than .js/.jsx', function() {
+  describe('transforming files with extensions other than .js/.jsx', function() {
 
     it('activates via extension option', function(done) {
       browserify('./fixtures/main.jsnox', {basedir: __dirname})
@@ -115,9 +115,24 @@ describe('reactify', function() {
 
   });
 
+  describe('transforming with es5 as a target', function() {
+
+    it('activates via target option', function(done) {
+      browserify('./fixtures/main.es6-target-es5.jsx', {basedir: __dirname})
+        .transform({es6: true, target: 'es5'}, reactify)
+        .bundle(function(err, result) {
+          assert(!err);
+          assert(result);
+          assertContains(result, ' Object.defineProperty(Foo.prototype,"bar",{enumerable:true,configurable:true,get:function() {"use strict";');
+          done();
+        });
+    });
+
+  });
+
   describe('transforming with custom visitors', function() {
 
-    it('activates via es6 option', function(done) {
+    it('activates via visitors option', function(done) {
       browserify('./fixtures/main.es6-custom.jsx', {basedir: __dirname})
         .transform({visitors: 'es6-module-jstransform/visitors'}, reactify)
         .bundle(function(err, result) {


### PR DESCRIPTION
<strike>es5 compatibility is already assumed for some of the harmony transforms so this shouldn't affect any previous behavior</strike>

es6 class getters and setters require es5 as target
activate them with new option: `--target es5`
