### PR TITLE
#19 - Include inline source map comment in transformed output

### DIFF
--- a/test/reactify.js
+++ b/test/reactify.js
@@ -9,7 +9,7 @@ describe('reactify', function() {
     return browserify(entry, {basedir: __dirname})
       .transform(coffeeify)
       .transform(reactify)
-      .bundle(cb);
+      .bundle({debug: true}, cb);
   };
 
   function normalizeWhitespace(src) {
@@ -54,6 +54,15 @@ describe('reactify', function() {
       assert(err);
       assertContains(String(err), 'Parse Error: Line 6: Unexpected token');
       assert(!result);
+      done();
+    });
+  });
+
+  it('includes embedded source map', function(done) {
+    bundle('./fixtures/main.jsx', function(err, result) {
+      assert(!err);
+      assert(result);
+      assertContains(result, '//# sourceMappingURL=data:application/json;base64');
       done();
     });
   });


### PR DESCRIPTION
The Mocha test is very simple but I have also verified in an actual browser that the mappings work. The inlineSourceMap function is copied from react-tools since it wasn't public. Implements #19