### PR TITLE
make normalizeWhitespace strip carriage returns

### DIFF
--- a/test/reactify.js
+++ b/test/reactify.js
@@ -13,7 +13,7 @@ describe('reactify', function() {
   };
 
   function normalizeWhitespace(src) {
-    return src.replace(/\n/g, '').replace(/ +/g, '');
+    return src.replace(/\n/g, '').replace(/\r/g, '').replace(/ +/g, '');
   }
 
   function assertContains(bundle, code) {


### PR DESCRIPTION
A couple of the tests were failing for me on Windows, which it turned out was because some carriage returns were getting in there and not being stripped out during the tests. Not sure if this is Windows-only, but anyway, this fixes it.