### PR TITLE
Use peerDependencies instead of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "dependencies": {
     "through": "~2.3.4",
-    "react-tools": "~0.12.1"
+  },
+  "peerDependencies": {
+    "react-tools": ">=0.12.1"
   },
   "devDependencies": {
     "browserify": "4.x.x",


### PR DESCRIPTION
Requiring react-tools as dependencies, means the transpilation is only
possible with the version on reactify package.json. By moving to
peerDependencies, when requiring a different version of React the 
transpilation should just work. Of course this might eventually break but
different projects will want to use different versions of the trnaspiler
anyway, so I am suggesting to addopt peerDependencies.

The main reason I am creating this pull-request is that I am using new
features on React 0.13-rc1 and I need the transpilation to be in the same
version I am requiring from React.

I hope you like the idea, though in the long run, if react-tools introduce API
changes, it might mean supporting more then one version at a time.