### PR TITLE
Add reactOptions option

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,13 +19,7 @@ function reactify(filename, options) {
     // jshint -W040
     if (isJSXFile(filename, options)) {
       try {
-        var output = ReactTools.transform(source, {
-          es5: options.target === 'es5',
-          sourceMap: true,
-          sourceFilename: filename,
-          stripTypes: options['strip-types'] || options.stripTypes,
-          harmony: options.harmony || options.es6
-        });
+        var output = ReactTools.transform(source, getTransformOptions(options, filename));
         this.queue(output);
       } catch (error) {
         error.name = 'ReactifyError';
@@ -54,6 +48,25 @@ function isJSXFile(filename, options) {
       .map(function(ext) { return ext[0] === '.' ? ext.slice(1) : ext });
     return new RegExp('\\.(' + extensions.join('|') + ')$').exec(filename);
   }
+}
+
+function getTransformOptions(options, filename) {
+  var out = {
+    es5: options.target === 'es5',
+    sourceMap: true,
+    sourceFilename: filename,
+    stripTypes: options['strip-types'] || options.stripTypes,
+    harmony: options.harmony || options.es6
+  }
+
+  var reactOpts = options.reactOptions;
+  if (reactOpts) {
+    for (var k in reactOpts) {
+      out[k] = reactOpts[k];
+    }
+  }
+
+  return out;
 }
 
 module.exports = reactify;

--- a/test/fixtures/main.strip-import-types.js
+++ b/test/fixtures/main.strip-import-types.js
@@ -1,0 +1,9 @@
+/* @flow */
+
+import type * as URI from 'URI';
+
+var myFunction = function(text: string, length: number): string {
+  return string.substr(0, length);
+}
+
+module.exports = myFunction;

--- a/test/reactify.js
+++ b/test/reactify.js
@@ -169,6 +169,17 @@ describe('reactify', function() {
         });
     });
 
+    it('strips import types with es6modules option', function(done) {
+      browserify('./fixtures/main.strip-import-types.js', {basedir: __dirname})
+        .transform({stripTypes: true, reactOptions: {es6module: true}}, reactify)
+        .bundle(function(err, result) {
+          assert(!err);
+          assert(result);
+          assert(result.indexOf('import') == -1, "'import type' statement was not removed.");
+          done();
+        });
+    });
+
   });
 
   describe('stripping types and transform with es6 visitors', function() {


### PR DESCRIPTION
This passes directly through to `reactTools.transform`.

It should eliminate the need to ever update reactify when react-tools adds new options, e.g. the recent `es6module` and `nonStrictEs6Module` options which are required for [import type][1] statements in Flow.

This is generally a good idea for options passing. For example, grunt-browserify [did something similar][2] recently.

This would supersede #48, #52, #56 and any future PR to modify how reactify handles react-tools options :)

cc @jeffmo

[1]: http://flowtype.org/blog/2015/02/18/Import-Types.html
[2]: https://github.com/jmreidy/grunt-browserify#30-release