### PR TITLE
Allow user to specify their own file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ If you want to reactify modules with other extensions, pass an `-x /
 
     % browserify -t coffeeify -t [ reactify --extension coffee ] main.coffee
 
+If you want to specify your own extensions, pass an `--extensions` option:
+
+    % browserify -t [ reactify --extensions jsx,coffee ] main.jsx
+
 If you don't want to specify extension, just pass `--everything` option:
 
     % browserify -t coffeeify -t [ reactify --everything ] main.coffee

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function isJSXFile(filename, options) {
   if (options.everything) {
     return true;
   } else {
-    var extensions = ['js', 'jsx']
+    var extensions = (options.extensions) ? options.extensions.split(',') : ['js', 'jsx']
       .concat(options.extension)
       .concat(options.x)
       .filter(Boolean)


### PR DESCRIPTION
The benefit now is that you can specify an exclusive list of
extensions to process, for instance only `jsx` files.

Ideally, the existing `--extension|-x` option can be removed
because you can specify as many extensions as you want now, but
I left it in there because I didn't want to break any existing
functionality.