### PR TITLE
Adding 'exclude' option

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
 var ReactTools = require('react-tools');
 var through    = require('through');
 var minimatch  = require('minimatch');
-var path       = require('path')
+var path       = require('path');
 
 function reactify(filename, options) {
   options = options || {};
@@ -51,7 +51,9 @@ function reactify(filename, options) {
 }
 
 function isJSXFile(filename, exclude, options) {
-  var relativeName = path.relative(process.cwd(), filename);
+  // Getting base dir from own options, browserify options or from current working dir
+  var baseDir = options.basedir || (options._flags && options._flags.basedir) || process.cwd();
+  var relativeName = path.relative(baseDir, filename);
 
   if (exclude.some(function(matcher) {
     return matcher.match(relativeName);

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@
 
 var ReactTools = require('react-tools');
 var through    = require('through');
+var minimatch  = require('minimatch');
+var flatten    = require('flatten');
 
 function reactify(filename, options) {
   options = options || {};
@@ -48,6 +50,12 @@ function reactify(filename, options) {
 }
 
 function isJSXFile(filename, options) {
+  if (options.exclude && flatten([options.exclude]).some(function (pattern) {
+    return minimatch(filename, pattern, { matchBase: true });
+  })) {
+    return false;
+  }
+
   if (options.everything) {
     return true;
   } else {

--- a/index.js
+++ b/index.js
@@ -6,11 +6,12 @@
 var ReactTools = require('react-tools');
 var through    = require('through');
 var minimatch  = require('minimatch');
-var flatten    = require('flatten');
+var path       = require('path')
 
 function reactify(filename, options) {
   options = options || {};
 
+  var exclude = computeExcluded(options.exclude);
   var buf = [];
 
   function write(chunk) {
@@ -23,7 +24,7 @@ function reactify(filename, options) {
   function compile() {
     var source = Buffer.concat(buf).toString();
     // jshint -W040
-    if (isJSXFile(filename, options)) {
+    if (isJSXFile(filename, exclude, options)) {
       try {
         var output = ReactTools.transform(source, {
           es5: options.target === 'es5',
@@ -49,9 +50,11 @@ function reactify(filename, options) {
   return through(write, compile);
 }
 
-function isJSXFile(filename, options) {
-  if (options.exclude && flatten([options.exclude]).some(function (pattern) {
-    return minimatch(filename, pattern, { matchBase: true });
+function isJSXFile(filename, exclude, options) {
+  var relativeName = path.relative(process.cwd(), filename);
+
+  if (exclude.some(function(matcher) {
+    return matcher.match(relativeName);
   })) {
     return false;
   }
@@ -66,6 +69,16 @@ function isJSXFile(filename, options) {
       .map(function(ext) { return ext[0] === '.' ? ext.slice(1) : ext });
     return new RegExp('\\.(' + extensions.join('|') + ')$').exec(filename);
   }
+}
+
+function computeExcluded(excluded) {
+  if (!excluded) {
+    return [];
+  }
+
+  return (Array.isArray(excluded) ? excluded : [excluded]).map(function (pattern) {
+    return minimatch.Minimatch(pattern);
+  });
 }
 
 module.exports = reactify;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "dependencies": {
     "through": "~2.3.4",
-    "react-tools": "~0.13.0"
+    "react-tools": "~0.13.0",
+    "flatten": "0.0.1",
+    "minimatch": "^2.0.8"
   },
   "devDependencies": {
     "browserify": "4.x.x",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "dependencies": {
     "through": "~2.3.4",
     "react-tools": "~0.13.0",
-    "flatten": "0.0.1",
-    "minimatch": "^2.0.8"
+    "minimatch": "~2.0.8"
   },
   "devDependencies": {
     "browserify": "4.x.x",


### PR DESCRIPTION
Something that might be useful for #30, since it allows explicitly exclude files or folders from being transformed. Just a draft for discussion.

```js
browserify().transform(['reactify', {
  es6: true,
  target: 'es5',
  exclude: [
    '**/lib/**/*.js'
  ]
}])
```